### PR TITLE
Some small README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
-# ocamlrep: Interop Ocaml and Rust code
+# ocamlrep: Interop OCaml and Rust code
 
-The goal of this project is make OCaml and Rust code interoperable.
-While in its early stage of development, this library is actively used
-by the [HHVM](https://github.com/facebook/hhvm) project, mostly in the Hack
-type checker, to make ocaml code rely on rust.
+The goal of this project is to make OCaml and Rust code interoperable. While in its early stage of development, this library is actively used by the [HHVM](https://github.com/facebook/hhvm) project, mostly in the Hack type checker, to make OCaml code rely on Rust.
 
 ## Requirements
-This project is stand-alone and should compile with recent versions of the
-ocaml compiler and rust echo-system.
+This project is stand-alone and should compile with recent versions of the OCaml compiler and Rust ecosystem.
 
 ocamlrep requires or works with:
-* Ocaml 4.14.0
-* Rust 1.65.0 (see Cargo.lock for third-party information)
+
+- OCaml 4.14.0
+- Rust 1.65.0 (see Cargo.lock for third-party information)
 
 ## Building ocamlrep
 TODO
 
+## Contributing
 See the [CONTRIBUTING](CONTRIBUTING.md) file for how to help out.
-
 
 ## License
 ocamlrep is using the MIT license, as found in the LICENSE file.


### PR DESCRIPTION
Small fix-ups to the README, mostly making the spelling of OCaml and Rust consistent.