### PR TITLE
Make ocamlpool compile with OCaml 5

### DIFF
--- a/ocamlpool/ocamlpool.c
+++ b/ocamlpool/ocamlpool.c
@@ -6,40 +6,20 @@
  */
 #define CAML_NAME_SPACE
 
-#include "ocamlpool.h"
-#include <caml/version.h>
-
 #include <stdio.h>
-
-#if OCAML_VERSION < 40700
-
-extern value* caml_young_ptr;
-extern uintnat caml_allocated_words;
-typedef struct {
-  void* block; /* address of the malloced block this chunk lives in */
-  asize_t alloc; /* in bytes, used for compaction */
-  asize_t size; /* in bytes */
-  char* next;
-} heap_chunk_head;
-
-#define Chunk_size(c) (((heap_chunk_head*)(c))[-1]).size
-
-#else
 
 #define CAML_INTERNALS
 
-#endif
+#include "ocamlpool.h"
 
 #include <caml/gc.h>
-#include <caml/major_gc.h>
 #include <caml/memory.h>
+#include <caml/misc.h>
+#include <caml/shared_heap.h>
 
 /* Global state
  * ===========================================================================
  */
-
-/* An OCaml root pointing to the current chunk, or Val_unit */
-static value ocamlpool_root = Val_unit;
 
 /* 1 iff we are inside an ocamlpool section */
 static int ocamlpool_in_section = 0;
@@ -48,17 +28,6 @@ static int ocamlpool_in_section = 0;
  * While inside the section, we check that the value has not changed as this
  * would result in difficult to track bugs. */
 static void* ocamlpool_sane_young_ptr;
-
-/* The GC color to give to blocks that are allocated inside the pool.
- * Updated when allocating a new chunk and when entering the section.  */
-color_t ocamlpool_color = 0;
-
-static int ocamlpool_allocated_chunks_counter = 0;
-static size_t ocamlpool_next_chunk_size = OCAMLPOOL_DEFAULT_SIZE;
-
-/* */
-uintnat ocamlpool_generation = 0;
-value *ocamlpool_limit = 0, *ocamlpool_cursor = 0, *ocamlpool_bound = 0;
 
 /* Sanity checks
  * ===========================================================================
@@ -73,9 +42,6 @@ static void abort_unless(int x, const char* message) {
     abort();
   }
 }
-
-#define WORD_SIZE (sizeof(void*))
-#define IS_WORD_ALIGNED(x) (((x) & (WORD_SIZE - 1)) == 0)
 
 #ifndef OCAMLPOOL_NO_ASSERT
 
@@ -101,9 +67,6 @@ static void assert_out_of_section(void) {
   ocamlpool_assert(ocamlpool_in_section == 0, "assert_out_of_section");
 }
 
-#define OCAMLPOOL_SET_HEADER(v, size, tag, color) \
-  *((header_t*)(((value*)(v)) - 1)) = Make_header(size, tag, color);
-
 /* OCamlpool sections
  * ===========================================================================
  *
@@ -115,127 +78,19 @@ static void assert_out_of_section(void) {
  * outlive the section.
  */
 
-static void init_cursor(void) {
-  ocamlpool_limit = (value*)ocamlpool_root;
-  ocamlpool_bound = (value*)ocamlpool_root + Wosize_val(ocamlpool_root);
-  ocamlpool_cursor = ocamlpool_bound;
-}
-
-static void ocamlpool_chunk_alloc(void);
-
-__attribute__((no_sanitize("undefined"))) static void ocamlpool_chunk_truncate(
-    void) {
-  if (ocamlpool_root == Val_unit) {
-    return;
-  }
-
-  size_t word_size = (value*)ocamlpool_cursor - (value*)ocamlpool_root;
-
-  OCAMLPOOL_SET_HEADER(ocamlpool_root, word_size, String_tag, ocamlpool_color);
-  value* first_word = (value*)ocamlpool_root;
-  first_word[word_size - 1] = 0;
-}
-
 void ocamlpool_enter(void) {
   assert_out_of_section();
 
-  static int ocamlpool_initialized = 0;
-  if (ocamlpool_initialized == 0) {
-    ocamlpool_initialized = 1;
-    caml_register_global_root(&ocamlpool_root);
-  }
-
-  if (ocamlpool_root != Val_unit) {
-    ocamlpool_color = caml_allocation_color((void*)ocamlpool_root);
-    init_cursor();
-  } else {
-    ocamlpool_chunk_alloc();
-  }
-
   ocamlpool_in_section = 1;
   ocamlpool_sane_young_ptr = caml_young_ptr;
-
-  assert_in_section();
 }
 
 void ocamlpool_leave(void) {
-  if (ocamlpool_in_section != 1) {
-    return;
-  }
-
   assert_in_section();
 
-  ocamlpool_chunk_truncate();
   ocamlpool_in_section = 0;
-  ocamlpool_limit = 0;
-  ocamlpool_bound = 0;
-  ocamlpool_cursor = 0;
 
-  ocamlpool_generation += 1;
-
-  assert_out_of_section();
-}
-
-/* Memory chunking
- * ===========================================================================
- *
- * Pool memory is allocated by large chunks.
- * The default settings should work well, though it is possible to tweak
- * and monitor these parameters.
- *
- * FIXME: The current chunking system might be incorrect if the incremental
- *        scan stops in the middle of the unallocated chunk.
- *        To prevent that, this chunk is marked as non-scannable (a string),
- *        but I should double check the behavior of Obj.truncate.
- */
-
-/* Number of chunks allocated by ocamlpool since beginning of execution */
-int ocamlpool_allocated_chunks(void) {
-  return ocamlpool_allocated_chunks_counter;
-}
-
-/* Controlling the size of allocated chunks.
- * Must be multiple of sizeof(void*), preferably >= 2^20. */
-size_t ocamlpool_get_next_chunk_size(void) {
-  return ocamlpool_next_chunk_size;
-}
-
-void ocamlpool_set_next_chunk_size(size_t sz) {
-  abort_unless(IS_WORD_ALIGNED(sz), "ocamlpool_set_next_chunk_size");
-  ocamlpool_next_chunk_size = sz;
-}
-
-void ocamlpool_chunk_release(void) {
-  ocamlpool_chunk_truncate();
-  ocamlpool_limit = 0;
-  ocamlpool_bound = 0;
-  ocamlpool_cursor = 0;
-  ocamlpool_root = Val_unit;
-}
-
-static void ocamlpool_chunk_alloc(void) {
-  ocamlpool_assert(
-      ocamlpool_next_chunk_size > 1,
-      "ocamlpool_chunk_alloc: next chunk size > 1");
-  void* block = caml_alloc_for_heap(ocamlpool_next_chunk_size * WORD_SIZE);
-  abort_unless(block != NULL, "ocamlpool_chunk_alloc");
-
-  size_t chunk_size = Chunk_size(block);
-  ocamlpool_assert(
-      IS_WORD_ALIGNED(chunk_size), "ocamlpool_chunk_alloc: is word-aligned");
-
-  ocamlpool_color = caml_allocation_color(block);
-  ocamlpool_allocated_chunks_counter += 1;
-
-  size_t words = (chunk_size / WORD_SIZE);
-
-  // Adjust root to account for ocaml header
-  ocamlpool_root = (value)((value*)block + 1);
-  OCAMLPOOL_SET_HEADER(ocamlpool_root, words - 1, String_tag, ocamlpool_color);
-  init_cursor();
-  caml_add_to_heap(block);
-
-  caml_allocated_words += words;
+  caml_process_pending_actions();
 }
 
 /* OCaml value allocations
@@ -243,42 +98,16 @@ static void ocamlpool_chunk_alloc(void) {
  *
  * A fast way to reserve OCaml memory when inside ocamlpool section.
  */
-value ocamlpool_reserve_block(int tag, size_t words) {
-  // Add 1 word for rust header
-  size_t size = words + 1;
-  value* pointer = ocamlpool_cursor - size;
+value ocamlpool_reserve_block(tag_t tag, mlsize_t wosize) {
+  caml_domain_state * d = Caml_state;
+  value *p = caml_shared_try_alloc(d->shared_heap, wosize, tag, 0);
+  d->allocated_words += Whsize_wosize(wosize);
 
-  if (pointer < ocamlpool_limit || pointer >= ocamlpool_bound) {
-    size_t old_ocamlpool_next_chunk_size = ocamlpool_next_chunk_size;
-    if (size >= ocamlpool_next_chunk_size) {
-      // Add 1 word for ocaml's header
-      ocamlpool_next_chunk_size = size + 1;
-    }
-    ocamlpool_chunk_truncate();
-    ocamlpool_chunk_alloc();
-    ocamlpool_next_chunk_size = old_ocamlpool_next_chunk_size;
-    pointer = ocamlpool_cursor - size;
-    abort_unless(pointer >= ocamlpool_limit, "ocamlpool_reserve_block");
+  if (p == NULL) {
+    /* TODO: handle this case... */
+    abort();
   }
 
-  ocamlpool_cursor = pointer;
-  value result = (value)(pointer + 1);
-
-  OCAMLPOOL_SET_HEADER(result, words, tag, ocamlpool_color);
-  return result;
-}
-
-value ocamlpool_reserve_string(size_t bytes) {
-  assert_in_section();
-
-  size_t words =
-      ((bytes + 1 /*null-ending*/ + (WORD_SIZE - 1) /*rounding*/) / WORD_SIZE);
-  size_t length = (words * WORD_SIZE);
-
-  value result = ocamlpool_reserve_block(String_tag, words);
-
-  ((value*)result)[words - 1] = 0;
-  ((char*)result)[length - 1] = length - bytes - 1;
-
-  return result;
+  Hd_hp(p) = Make_header(wosize, tag, caml_global_heap_state.MARKED);
+  return Val_hp(p);
 }

--- a/ocamlpool/ocamlpool.h
+++ b/ocamlpool/ocamlpool.h
@@ -42,41 +42,12 @@
 void ocamlpool_enter(void);
 void ocamlpool_leave(void);
 
-/* Memory chunking
- * ===========================================================================
- *
- * Pool memory is allocated by large chunks.
- * The default settings should work well, though it is possible to tweak
- * and monitor these parameters.
- *
- */
-
-/* Number of chunks allocated by ocamlpool since beginning of execution */
-int ocamlpool_allocated_chunks(void);
-
-/* Controlling the size of allocated chunks.
- * >= 512, preferably >= 2^20
- *
- * NOTE: When changing this value, change the magic number in ocamlpool_test.rs
- */
-#define OCAMLPOOL_DEFAULT_SIZE (1024 * 1024)
-size_t ocamlpool_get_next_chunk_size(void);
-void ocamlpool_set_next_chunk_size(size_t sz);
-
-/* Return the current chunk to OCaml memory system */
-void ocamlpool_chunk_release(void);
-
 /* OCaml value allocations
  * ===========================================================================
  *
  * A fast to reserve OCaml memory when inside ocamlpool section.
  */
 
-value ocamlpool_reserve_string(size_t bytes);
-value ocamlpool_reserve_block(int tag, size_t words);
-
-extern color_t ocamlpool_color;
-extern value *ocamlpool_limit, *ocamlpool_cursor, *ocamlpool_bound;
-extern uintnat ocamlpool_generation;
+value ocamlpool_reserve_block(tag_t tag, mlsize_t words);
 
 #endif /*!OCAMLPOOL_H*/


### PR DESCRIPTION
!! This is super hacky !!

This code used CAML_INTERNALS which understandably broke in OCaml 5. The new code is modeled after OCaml 5.0's intern.c.

This is just for experimentation, and should not be merged with trunk.