### PR TITLE
fix broken test paths; ocamlpool 5.0 candidate fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ Cargo.lock
 *.o
 *.cmx
 *.cmi
+*.a
+*.cmxa
 ocamlrep_test
 ocamlpool_test
 counter_test
+ocamlrep_marshal_test

--- a/ocamlpool/ocamlpool.c
+++ b/ocamlpool/ocamlpool.c
@@ -6,12 +6,14 @@
  */
 #define CAML_NAME_SPACE
 
-#include "ocamlpool.h"
 #include <caml/version.h>
-
 #include <stdio.h>
 
-#if OCAML_VERSION < 40700
+#if OCAML_VERSION < 50000
+
+#  include "ocamlpool.h"
+
+#  if OCAML_VERSION < 40700
 
 extern value* caml_young_ptr;
 extern uintnat caml_allocated_words;
@@ -22,17 +24,17 @@ typedef struct {
   char* next;
 } heap_chunk_head;
 
-#define Chunk_size(c) (((heap_chunk_head*)(c))[-1]).size
+#    define Chunk_size(c) (((heap_chunk_head*)(c))[-1]).size
 
-#else
+#  else
 
-#define CAML_INTERNALS
+#    define CAML_INTERNALS
 
-#endif
+#  endif /* OCAML_VERSION < 40700 */
 
-#include <caml/gc.h>
-#include <caml/major_gc.h>
-#include <caml/memory.h>
+#  include <caml/gc.h>
+#  include <caml/major_gc.h>
+#  include <caml/memory.h>
 
 /* Global state
  * ===========================================================================
@@ -74,22 +76,22 @@ static void abort_unless(int x, const char* message) {
   }
 }
 
-#define WORD_SIZE (sizeof(void*))
-#define IS_WORD_ALIGNED(x) (((x) & (WORD_SIZE - 1)) == 0)
+#  define WORD_SIZE (sizeof(void*))
+#  define IS_WORD_ALIGNED(x) (((x) & (WORD_SIZE - 1)) == 0)
 
-#ifndef OCAMLPOOL_NO_ASSERT
+#  ifndef OCAMLPOOL_NO_ASSERT
 
 static void ocamlpool_assert(int x, const char* message) {
   abort_unless(x, message);
 }
 
-#else
+#  else
 
 static void ocamlpool_assert(int x, const char* message) {
   (void)x;
 }
 
-#endif
+#  endif /* !defined(OCAMLPOOL_NO_ASSERT) */
 
 static void assert_in_section(void) {
   ocamlpool_assert(
@@ -101,7 +103,7 @@ static void assert_out_of_section(void) {
   ocamlpool_assert(ocamlpool_in_section == 0, "assert_out_of_section");
 }
 
-#define OCAMLPOOL_SET_HEADER(v, size, tag, color) \
+#  define OCAMLPOOL_SET_HEADER(v, size, tag, color) \
   *((header_t*)(((value*)(v)) - 1)) = Make_header(size, tag, color);
 
 /* OCamlpool sections
@@ -282,3 +284,112 @@ value ocamlpool_reserve_string(size_t bytes) {
 
   return result;
 }
+#else /* >= ocaml-5.0 */
+
+#  define CAML_INTERNALS
+
+#  include "ocamlpool.h"
+
+#  include <caml/gc.h>
+#  include <caml/memory.h>
+#  include <caml/misc.h>
+#  include <caml/shared_heap.h>
+
+/* Global state
+ * ===========================================================================
+ */
+
+/* 1 iff we are inside an ocamlpool section */
+static int ocamlpool_in_section = 0;
+
+/* For sanity checks, caml_young_ptr is copied when entering the section.
+ * While inside the section, we check that the value has not changed as this
+ * would result in difficult to track bugs. */
+static void* ocamlpool_sane_young_ptr;
+
+/* Sanity checks
+ * ===========================================================================
+ *
+ * Contracts checking that the invariants are maintained inside the library
+ * and that the API is used correctly.
+ */
+
+static void abort_unless(int x, const char* message) {
+  if (!x) {
+    fprintf(stderr, "OCamlPool invariant violation (%d): %s\n", x, message);
+    abort();
+  }
+}
+
+#  ifndef OCAMLPOOL_NO_ASSERT
+
+static void ocamlpool_assert(int x, const char* message) {
+  abort_unless(x, message);
+}
+
+#  else
+
+static void ocamlpool_assert(int x, const char* message) {
+  (void)x;
+}
+
+#  endif /* !defined(OCAMLPOOL_NO_ASSERT) */
+
+static void assert_in_section(void) {
+  ocamlpool_assert(
+      ocamlpool_in_section == 1 && ocamlpool_sane_young_ptr == caml_young_ptr,
+      "assert_in_section");
+}
+
+static void assert_out_of_section(void) {
+  ocamlpool_assert(ocamlpool_in_section == 0, "assert_out_of_section");
+}
+
+/* OCamlpool sections
+ * ===========================================================================
+ *
+ * Inside the section, the OCaml heap will be in an invalid state.
+ * OCaml runtime functions should not be called.
+ *
+ * Since the GC will never run while in an OCaml pool section,
+ * it is safe to keep references to OCaml values as long as these does not
+ * outlive the section.
+ */
+
+void ocamlpool_enter(void) {
+  assert_out_of_section();
+
+  ocamlpool_in_section = 1;
+  ocamlpool_sane_young_ptr = caml_young_ptr;
+}
+
+void ocamlpool_leave(void) {
+  assert_in_section();
+
+  ocamlpool_in_section = 0;
+
+  // We require no GC until control has returned to OCaml thus we may
+  // not call this here!
+  // caml_process_pending_actions();
+}
+
+/* OCaml value allocations
+ * ===========================================================================
+ *
+ * A fast way to reserve OCaml memory when inside ocamlpool section.
+ */
+value ocamlpool_reserve_block(tag_t tag, mlsize_t wosize) {
+  caml_domain_state * d = Caml_state;
+  value *p = caml_shared_try_alloc(d->shared_heap, wosize, tag, 0);
+  d->allocated_words += Whsize_wosize(wosize);
+
+  if (p == NULL) {
+    /* TODO: handle this case... */
+    abort();
+  }
+
+  Hd_hp(p) = Make_header(wosize, tag, caml_global_heap_state.MARKED);
+  return Val_hp(p);
+}
+
+#endif /* OCAML_VERSION < 50000 */

--- a/ocamlrep/test/test_bindings.rs
+++ b/ocamlrep/test/test_bindings.rs
@@ -290,7 +290,7 @@ pub extern "C" fn roundtrip_int64(value: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    include! {"../../../cargo_test_utils/cargo_test_utils.rs"}
+    include! {"../../cargo_test_utils/cargo_test_utils.rs"}
 
     #[test]
     fn ocamlrep_test() {

--- a/ocamlrep_custom/test/counter.rs
+++ b/ocamlrep_custom/test/counter.rs
@@ -35,7 +35,7 @@ ocaml_ffi! {
 
 #[cfg(test)]
 mod tests {
-    include! {"../../../cargo_test_utils/cargo_test_utils.rs"}
+    include! {"../../cargo_test_utils/cargo_test_utils.rs"}
 
     #[test]
     fn counter_test() {

--- a/ocamlrep_marshal/ocamlrep_marshal_ffi_bindings.rs
+++ b/ocamlrep_marshal/ocamlrep_marshal_ffi_bindings.rs
@@ -38,7 +38,7 @@ unsafe extern "C" fn ocamlrep_marshal_input_value_from_string(
 
 #[cfg(test)]
 mod tests {
-    include! {"../../cargo_test_utils/cargo_test_utils.rs"}
+    include! {"../cargo_test_utils/cargo_test_utils.rs"}
 
     #[test]
     fn ocamlrep_marshal_test() {


### PR DESCRIPTION
- the recent removal of the `rust` directory broke some tests, fix that
- install the candidate ocaml 5.0 implementation for ocamlpool so

tests:
(1) on the laptop
```
$(opam env --select=default --set-switch) # 4.14.0
cargo clean && cargo build && cargo test

$(opam env --select=5.0.0 --set-switch) # 5.0
cargo clean && cargo build && cargo test
```
(2) circleci (will at this time only test 4.14.0; 'config.yml' needs enhancing)