### PR TITLE
[ocamlrep_ocamlpool/test]: cargo test in isolation dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ Cargo.lock
 *.a
 *.cmxa
 ocamlrep_test
-ocamlpool_test
 counter_test
 ocamlrep_marshal_test

--- a/cargo_test_utils/cargo_test_utils.rs
+++ b/cargo_test_utils/cargo_test_utils.rs
@@ -1,25 +1,43 @@
 use std::process::Command;
 use std::process::ExitStatusError;
 
-pub fn cmd(prog: &str, args: &[&str]) -> Command {
+#[allow(dead_code)]
+fn cmd(prog: &str, args: &[&str]) -> Command {
     let mut prog_cmd = Command::new(prog);
     prog_cmd.args(args);
     prog_cmd
 }
 
-pub fn ocamlopt_cmd(args: &[&str]) -> Command {
+#[allow(dead_code)]
+fn cmd_with_current_dir(prog: &str, args: &[&str], dir: &std::path::Path) -> Command {
+    let mut prog_cmd = Command::new(prog);
+    prog_cmd.current_dir(dir);
+    prog_cmd.args(args);
+    prog_cmd
+}
+
+#[allow(dead_code)]
+fn ocamlopt_cmd(args: &[&str]) -> Command {
     cmd("ocamlopt.opt", args)
 }
 
-pub fn sh_cmd(args: &[&str]) -> Command {
+#[allow(dead_code)]
+fn sh_cmd(args: &[&str]) -> Command {
     cmd("sh", args)
 }
 
-pub fn cargo_cmd(args: &[&str]) -> Command {
+#[allow(dead_code)]
+fn sh_cmd_with_current_dir(args: &[&str], dir: &std::path::Path) -> Command {
+    cmd_with_current_dir("sh", args, dir)
+}
+
+#[allow(dead_code)]
+fn cargo_cmd(args: &[&str]) -> Command {
     cmd("cargo", args)
 }
 
-pub fn workspace_dir(ds: &[&str]) -> std::path::PathBuf {
+#[allow(dead_code)]
+fn workspace_dir(ds: &[&str]) -> std::path::PathBuf {
     let mut cargo_cmd = cargo_cmd(&["locate-project", "--workspace", "--message-format=plain"]);
     let output = cargo_cmd.output().unwrap().stdout;
     let root_cargo_toml = std::path::Path::new(std::str::from_utf8(&output).unwrap().trim());
@@ -30,15 +48,18 @@ pub fn workspace_dir(ds: &[&str]) -> std::path::PathBuf {
     p
 }
 
-pub fn run(mut cmd: Command) -> Result<(), ExitStatusError> {
+#[allow(dead_code)]
+fn run(mut cmd: Command) -> Result<(), ExitStatusError> {
     cmd.spawn().unwrap().wait().ok().unwrap().exit_ok()
 }
 
-pub fn fmt_exit_status_err(err: ExitStatusError) -> String {
+#[allow(dead_code)]
+fn fmt_exit_status_err(err: ExitStatusError) -> String {
     format!("error status: {err}")
 }
 
-pub fn build_flavor() -> &'static str {
+#[allow(dead_code)]
+fn build_flavor() -> &'static str {
     if cfg!(debug_assertions) {
         "debug"
     } else {

--- a/ocamlrep_ocamlpool/test/Cargo.toml
+++ b/ocamlrep_ocamlpool/test/Cargo.toml
@@ -14,4 +14,6 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
+anyhow = "1.0.69"
+tempdir = "0.3.7"
 ocamlrep_ocamlpool = { path = ".." }


### PR DESCRIPTION
`ocamlpool_test` is a rust library implementing an ocaml ffi. the `#[cfg(test)]` section defines a test function `ocamlpool_test` that compiles & executes an ocaml program that exercises that ffi.

rather than the compilation artifacts of that build being written into the 'ocamlrep1 source tree, do the compilation "off-to-the-side" in a temporary directory that is garbage collected when the test completes.