### PR TITLE
Allow wasm32 compilation

### DIFF
--- a/ocamlrep/impls.rs
+++ b/ocamlrep/impls.rs
@@ -773,7 +773,8 @@ impl ToOcamlRep for OsStr {
 
     #[cfg(target_arch = "wasm32")]
     fn to_ocamlrep<'a, A: Allocator>(&'a self, alloc: &'a A) -> Value<'a> {
-        panic!()
+        use std::os::wasi::ffi::OsStrExt;
+        alloc.add(self.as_bytes())
     }
 }
 
@@ -786,7 +787,8 @@ impl ToOcamlRep for &'_ OsStr {
 
     #[cfg(target_arch = "wasm32")]
     fn to_ocamlrep<'a, A: Allocator>(&'a self, alloc: &'a A) -> Value<'a> {
-        panic!()
+        use std::os::wasi::ffi::OsStrExt;
+        alloc.add(self.as_bytes())
     }
 }
 
@@ -801,7 +803,10 @@ impl<'a> FromOcamlRepIn<'a> for &'a OsStr {
 
     #[cfg(target_arch = "wasm32")]
     fn from_ocamlrep_in<'b>(value: Value<'b>, alloc: &'a Bump) -> Result<Self, FromError> {
-        panic!()
+        use std::os::wasi::ffi::OsStrExt;
+        Ok(std::ffi::OsStr::from_bytes(<&'a [u8]>::from_ocamlrep_in(
+            value, alloc,
+        )?))
     }
 }
 
@@ -822,7 +827,10 @@ impl FromOcamlRep for OsString {
 
     #[cfg(target_arch = "wasm32")]
     fn from_ocamlrep(value: Value<'_>) -> Result<Self, FromError> {
-        panic!()
+        use std::os::wasi::ffi::OsStrExt;
+        Ok(OsString::from(std::ffi::OsStr::from_bytes(
+            bytes_from_ocamlrep(value)?,
+        )))
     }
 }
 

--- a/ocamlrep/impls.rs
+++ b/ocamlrep/impls.rs
@@ -773,8 +773,7 @@ impl ToOcamlRep for OsStr {
 
     #[cfg(target_arch = "wasm32")]
     fn to_ocamlrep<'a, A: Allocator>(&'a self, alloc: &'a A) -> Value<'a> {
-        use std::os::wasi::ffi::OsStrExt;
-        alloc.add(self.as_bytes())
+        panic!()
     }
 }
 
@@ -787,8 +786,7 @@ impl ToOcamlRep for &'_ OsStr {
 
     #[cfg(target_arch = "wasm32")]
     fn to_ocamlrep<'a, A: Allocator>(&'a self, alloc: &'a A) -> Value<'a> {
-        use std::os::wasi::ffi::OsStrExt;
-        alloc.add(self.as_bytes())
+        panic!()
     }
 }
 
@@ -803,10 +801,7 @@ impl<'a> FromOcamlRepIn<'a> for &'a OsStr {
 
     #[cfg(target_arch = "wasm32")]
     fn from_ocamlrep_in<'b>(value: Value<'b>, alloc: &'a Bump) -> Result<Self, FromError> {
-        use std::os::wasi::ffi::OsStrExt;
-        Ok(std::ffi::OsStr::from_bytes(<&'a [u8]>::from_ocamlrep_in(
-            value, alloc,
-        )?))
+        panic!()
     }
 }
 
@@ -827,10 +822,7 @@ impl FromOcamlRep for OsString {
 
     #[cfg(target_arch = "wasm32")]
     fn from_ocamlrep(value: Value<'_>) -> Result<Self, FromError> {
-        use std::os::wasi::ffi::OsStrExt;
-        Ok(OsString::from(std::ffi::OsStr::from_bytes(
-            bytes_from_ocamlrep(value)?,
-        )))
+        panic!()
     }
 }
 

--- a/ocamlrep/impls.rs
+++ b/ocamlrep/impls.rs
@@ -770,6 +770,11 @@ impl ToOcamlRep for OsStr {
         use std::os::unix::ffi::OsStrExt;
         alloc.add(self.as_bytes())
     }
+
+    #[cfg(target_arch = "wasm32")]
+    fn to_ocamlrep<'a, A: Allocator>(&'a self, alloc: &'a A) -> Value<'a> {
+        panic!()
+    }
 }
 
 impl ToOcamlRep for &'_ OsStr {
@@ -778,14 +783,25 @@ impl ToOcamlRep for &'_ OsStr {
         use std::os::unix::ffi::OsStrExt;
         alloc.add(self.as_bytes())
     }
+
+    #[cfg(target_arch = "wasm32")]
+    fn to_ocamlrep<'a, A: Allocator>(&'a self, alloc: &'a A) -> Value<'a> {
+        panic!()
+    }
 }
 
 impl<'a> FromOcamlRepIn<'a> for &'a OsStr {
+    #[cfg(unix)]
     fn from_ocamlrep_in<'b>(value: Value<'b>, alloc: &'a Bump) -> Result<Self, FromError> {
         use std::os::unix::ffi::OsStrExt;
         Ok(std::ffi::OsStr::from_bytes(<&'a [u8]>::from_ocamlrep_in(
             value, alloc,
         )?))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn from_ocamlrep_in<'b>(value: Value<'b>, alloc: &'a Bump) -> Result<Self, FromError> {
+        panic!()
     }
 }
 
@@ -802,6 +818,11 @@ impl FromOcamlRep for OsString {
         Ok(OsString::from(std::ffi::OsStr::from_bytes(
             bytes_from_ocamlrep(value)?,
         )))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn from_ocamlrep(value: Value<'_>) -> Result<Self, FromError> {
+        panic!()
     }
 }
 

--- a/ocamlrep/lib.rs
+++ b/ocamlrep/lib.rs
@@ -351,7 +351,7 @@ pub use value::Value;
 // TODO: find the right forever home for these constants
 
 // 'mlvalues.h'
-pub const MAX_WOSIZE: usize = ((1_isize << 54) - 1) as usize;
+pub const MAX_WOSIZE: u64 = ((1_i64 << 54) - 1) as u64;
 pub const DOUBLE_WOSIZE: usize = std::mem::size_of::<f64>() / std::mem::size_of::<usize>();
 
 // 'gc.h'

--- a/ocamlrep/lib.rs
+++ b/ocamlrep/lib.rs
@@ -351,7 +351,6 @@ pub use value::Value;
 // TODO: find the right forever home for these constants
 
 // 'mlvalues.h'
-pub const MAX_WOSIZE: u64 = ((1_i64 << 54) - 1) as u64;
 pub const DOUBLE_WOSIZE: usize = std::mem::size_of::<f64>() / std::mem::size_of::<usize>();
 
 // 'gc.h'


### PR DESCRIPTION
This allows for compilation to wasm32. These changes are necessary to build for things like https://hakana.dev