### PR TITLE
macOS resource deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       macOS cargo build & test
     macos:
       xcode: 13.4.1
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - setup_macos_env
@@ -161,7 +161,7 @@ jobs:
       macOS buck build
     macos:
       xcode: 13.4.1
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - setup_macos_env


### PR DESCRIPTION
as explained in https://discuss.circleci.com/t/macos-resource-deprecation-in-2023/45701 the "medium" and "large" macOS resource classes are deprecated. try updating to `macos.x86.medium.gen2`