### PR TITLE
Update Buck2 installation instructions

### DIFF
--- a/README-BUCK.md
+++ b/README-BUCK.md
@@ -4,15 +4,30 @@
 
 These are things that need to be done once to get going.
 
-### Install Buck2 and Reindeer
+### Install Buck2
 
-These commands install the `buck2` and `reindeer` binaries into '~/.cargo/bin'.
+Buck2 provides prebuilt binaries. For example the following commands will install a prebuilt Buck2 and symlink it into `/usr/local/bin`.
 ```bash
-    cargo install --git https://github.com/facebook/buck2.git buck2
-    cargo install --git https://github.com/facebookincubator/reindeer.git reindeer
+  wget https://github.com/facebook/buck2/releases/download/latest/buck2-"$PLAT".zst
+  zstd -d buck2-"$PLAT".zst -o buck2
+  chmod +x buck2
+  sudo ln -s "$(pwd)"/buck2 /usr/local/bin/buck2
+```
+Valid values for `$PLAT` are `x86_64-unknown-linux-gnu` on Linux or `x86_64-apple-darwin` on x86 macOS.
+
+It's also possible to install Buck2 from source into `~/.cargo/bin` like this.
+```bash
+  cargo +nightly-2023-03-07 install --git https://github.com/facebook/buck2.git buck2
 ```
 
-*Note: Make sure after installing them to configure your `PATH` environment variable so they can be found.*
+### Install Reindeer
+
+Install the `reindeer` binary from source into '~/.cargo/bin' like this.
+```bash
+    cargo +nightly-2023-03-07 install --git https://github.com/facebookincubator/reindeer.git reindeer
+```
+
+*Note: Make sure after installing Buck2 and Reindeer to configure your `PATH` environment variable if necessary so they can be found.*
 
 ### Install the OCaml package Manager
 
@@ -20,7 +35,7 @@ If you haven't already, install [opam](https://opam.ocaml.org/).
 
 When opam has been installed execute `~/.ocaml-setup.sh` from the root of the distribution. The effect of `ocaml-setup.sh` is to create symlinks in `shim/third/party/ocaml` that point into the local opam installation.
 
-*Note: The script assumes that [`OPAM_SWITCH_PREFIX`](https://opam.ocaml.org/doc/Manual.html#Switches) has been set by the way.*
+*Note: The script assumes that [`OPAM_SWITCH_PREFIX`](https://opam.ocaml.org/doc/Manual.html#Switches) is set.*
 
 ## Vendor sources & generate buck rules for ocamlrep's Rust dependencies
 
@@ -38,6 +53,5 @@ Run this command from the root of the repository to build all the targets you ca
 ```
     buck2 build root//...
 ```
-To run all the tests you can, replace `build` with `test` in the above command.
 
 More examples and more detail about building with Buck2 are available on the [Buck2 website](https://buck2.build/)!

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ The goal of this project is to make OCaml and Rust code interoperable. While in 
 ## Requirements
 This project is stand-alone and requires or works with:
   - OCaml 4.14.0;
-  - A rust nightly toolchain [^1].
-
-[^1]: If you plan on using Buck2 for [building ocamlrep](#building-ocamlrep) we recommend `nightly-2023-01-24` at this time.
+  - A rust nightly toolchain.
 
 ## Building ocamlrep
 


### PR DESCRIPTION
Update the docs explaining we now prefer to download prebuilt Buck2 binaries rather than build it from source.