### PR TITLE
use macos.m1.medium.gen1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,6 @@ commands:
       - run:
           name: Brew install
           command: |
-            # Avoid `brew link` step errors
-            rm -f '/usr/local/lib/python3.9/site-packages/six.py'
-            brew unlink python@3.9
             brew install cmake coreutils opam llvm zstd wget
       - init_opam
       - run:
@@ -141,8 +138,8 @@ jobs:
     description: |
       macOS cargo build & test
     macos:
-      xcode: 13.4.1
-    resource_class: macos.x86.medium.gen2
+      xcode: "14.2.0"
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - setup_macos_env
@@ -168,13 +165,13 @@ jobs:
     description: |
       macOS buck build
     macos:
-      xcode: 13.4.1
-    resource_class: macos.x86.medium.gen2
+      xcode: "14.2.0"
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - setup_macos_env
       - install_buck:
-          triple: "x86_64-apple-darwin"
+          triple: "aarch64-apple-darwin"
       - install_reindeer
       - reindeer
       - buck_tp

--- a/README-BUCK.md
+++ b/README-BUCK.md
@@ -13,7 +13,7 @@ Buck2 provides prebuilt binaries. For example the following commands will instal
   chmod +x buck2
   sudo ln -s "$(pwd)"/buck2 /usr/local/bin/buck2
 ```
-Valid values for `$PLAT` are `x86_64-unknown-linux-gnu` on Linux or `x86_64-apple-darwin` on x86 macOS.
+Valid values for `$PLAT` are `x86_64-unknown-linux-gnu` on Linux, `x86_64-apple-darwin` on x86 macOS and `aarch64-apple-darwin` on ARM macOS.
 
 It's also possible to install Buck2 from source into `~/.cargo/bin` like this.
 ```bash


### PR DESCRIPTION
Summary: following buck's lead in D48169177, switch resource class to macos.m1.medium.gen1 changing the macos install buck platform triple to aarch64-apple-darwin accordingly. also update xcode to 14.2.0.

Differential Revision: D48180487

