### PR TITLE
Update serde from 1.0.176 to 1.0.185

### DIFF
--- a/shim/third-party/rust/fixups/serde_derive/fixups.toml
+++ b/shim/third-party/rust/fixups/serde_derive/fixups.toml
@@ -1,5 +1,0 @@
-# To set `CARGO_MANIFEST_DIR`
-cargo_env = true
-
-[platform_fixup.'cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))']
-extra_srcs = ["serde_derive-x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Summary: fixup.toml for serde_derive is removed (see also D48516549)

Reviewed By: zertosh

Differential Revision: D48544178

