### PR TITLE
support cxx shared libs symlink tree on windows

### DIFF
--- a/prelude/cxx/cxx_executable.bzl
+++ b/prelude/cxx/cxx_executable.bzl
@@ -511,7 +511,7 @@ def cxx_executable(ctx: AnalysisContext, impl_params: CxxRuleConstructorParams, 
     # - the symlink dir that's part of RPATH
     # - sub-sub-targets that reference shared library dependencies and their respective dwp
     # - [shared-libraries] - a json map that references the above rules.
-    if shared_libs_symlink_tree:
+    if isinstance(shared_libs_symlink_tree, Artifact):
         sub_targets["rpath-tree"] = [DefaultInfo(
             default_output = shared_libs_symlink_tree,
             other_outputs = [
@@ -668,7 +668,7 @@ _CxxLinkExecutableResult = record(
     # List of files/directories that should be present for executable to be run successfully
     runtime_files = list[ArgLike],
     # Optional shared libs symlink tree symlinked_dir action
-    shared_libs_symlink_tree = [Artifact, None],
+    shared_libs_symlink_tree = [list[Artifact], Artifact, None],
     linker_map_data = [CxxLinkerMapData, None],
 )
 

--- a/prelude/rust/rust_binary.bzl
+++ b/prelude/rust/rust_binary.bzl
@@ -233,7 +233,7 @@ def _rust_binary_common(
             },
         )]
 
-        if shared_libs_symlink_tree:
+        if isinstance(shared_libs_symlink_tree, Artifact):
             sub_targets_for_link_style["rpath-tree"] = [DefaultInfo(
                 default_output = shared_libs_symlink_tree,
                 other_outputs = [


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/buck2/pull/425

link_style="shared" doesn't seem to work on Windows. We have seen issues caused by missing dlls when migrating builds from buck1 to buck2.

Differential Revision: D49559885


