### PR TITLE
: change test plan to avoid oss failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ commands:
             reindeer --third-party-dir shim/third-party/rust buckify
 
   buck_tp:
-    description: Use buck to build third-party deps
+    description: Use buck to build third-party deps (we don't currently call this)
     steps:
       - run:
           name: Build 3rd party rust.
@@ -158,7 +158,6 @@ jobs:
           triple: "x86_64-unknown-linux-gnu"
       - install_reindeer
       - reindeer
-      - buck_tp
       - buck_ocamlrep
 
   macos-buck-build:
@@ -174,7 +173,6 @@ jobs:
           triple: "aarch64-apple-darwin"
       - install_reindeer
       - reindeer
-      - buck_tp
       - buck_ocamlrep
 
 workflows:

--- a/README-BUCK.md
+++ b/README-BUCK.md
@@ -17,7 +17,7 @@ Valid values for `$PLAT` are `x86_64-unknown-linux-gnu` on Linux, `x86_64-apple-
 
 It's also possible to install Buck2 from source into `~/.cargo/bin` like this.
 ```bash
-  cargo +nightly-2023-06-27 install --git https://github.com/facebook/buck2.git buck2
+  cargo +nightly-2023-07-10 install --git https://github.com/facebook/buck2.git buck2
 ```
 *Note: If on aarch64-apple-darwin then be sure install to `brew install protobuf` and for the now it's necessary to add
 ```bash
@@ -30,7 +30,7 @@ to the build environment.*
 
 Install the `reindeer` binary from source into '~/.cargo/bin' like this.
 ```bash
-    cargo +nightly-2023-06-27 install --git https://github.com/facebookincubator/reindeer.git reindeer
+    cargo +nightly-2023-07-10 install --git https://github.com/facebookincubator/reindeer.git reindeer
 ```
 
 *Note: Make sure after installing Buck2 and Reindeer to configure your `PATH` environment variable if necessary so they can be found.*


### PR DESCRIPTION
Summary:
the oss ocamlrep CircleCI buck builds started failing today (e.g. https://app.circleci.com/pipelines/github/facebook/ocamlrep/1288/workflows/e23800c9-bc36-4636-899c-ba38b4de8059/jobs/5072)

the error occurs after reindeer when we attempt to build all third-party rust deps like this `buck2 build shim//third-party/... -v 2`. the error looks like this
```
 --> shim/third-party/rust/vendor/windows-sys-0.52.0/src/Windows/mod.rs:6:1
  |
6 | pub mod Win32;
  | ^^^^^^^^^^^^^^
  |
```
the import is feature gated
```
#[cfg(feature = "Win32")]
#[doc = "Required features: `\"Win32\"`"]
pub mod Win32;
```
and at this time i am completely at a loss to understand how it is getting set?

while working this out, so as to stop the bleeding, disable this particular build/test (`buck2 build shim//third-party/... -v 2`) and just go on to build ocamlrep and test it (which is fine).

Differential Revision: D51635228


