### PR TITLE
: bump rust channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
       - run:
           name: Download rust
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2023-07-10 -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2023-10-01 -y
 
   init_opam:
     description: Initialize opam


### PR DESCRIPTION
Summary: the [skycastle ocamlrep-oss test](https://www.internalfb.com/intern/test/281475099197845?ref_report_id=0) has been failing since 12/3 (silently it seems). it's just that the test requires a rust channel bump because it builds buck2 from source ([error](https://internalfb.com/sandcastle/workflow/1855483046478305221/artifact/actionlog.1855483046511419604.stderr.1?selectedLines=760-762-1-1)).

Differential Revision: D52166315


