### PR TITLE
: ocaml-5.1.1 and introduce rust-toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
       - run:
           name: Download rust
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2023-10-01 -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
   init_opam:
     description: Initialize opam
@@ -17,7 +17,7 @@ commands:
       - run:
           name: Init opam
           command: |
-            opam init --compiler=5.1.0 --disable-sandboxing -y
+            opam init --compiler=5.1.1 --disable-sandboxing -y
 
   setup_ocaml_tp:
     description: Write symlinks shim/third-party/ocaml

--- a/README-BUCK.md
+++ b/README-BUCK.md
@@ -17,7 +17,7 @@ Valid values for `$PLAT` are `x86_64-unknown-linux-gnu` on Linux, `x86_64-apple-
 
 It's also possible to install Buck2 from source into `~/.cargo/bin` like this.
 ```bash
-  cargo +nightly-2023-07-10 install --git https://github.com/facebook/buck2.git buck2
+  cargo install --git https://github.com/facebook/buck2.git buck2
 ```
 *Note: If on aarch64-apple-darwin then be sure install to `brew install protobuf` and for the now it's necessary to add
 ```bash
@@ -30,7 +30,7 @@ to the build environment.*
 
 Install the `reindeer` binary from source into '~/.cargo/bin' like this.
 ```bash
-    cargo +nightly-2023-07-10 install --git https://github.com/facebookincubator/reindeer.git reindeer
+    cargo install --git https://github.com/facebookincubator/reindeer.git reindeer
 ```
 
 *Note: Make sure after installing Buck2 and Reindeer to configure your `PATH` environment variable if necessary so they can be found.*


### PR DESCRIPTION
Summary:
- use rust-toolchain for rustup to select channel and arrange documentation to keep it in sync with reindeer & buck2
- bump ocaml compiler to 5.1.1 as we've just done for buck2 D52803075

Differential Revision:
D52805706

Privacy Context Container: L1122763


