### PR TITLE
: ocaml-5.1.1 and introduce rust-toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,24 @@ aliases:
       equal: [ main, << pipeline.git.branch >> ]
 
 commands:
-  install_rust_toolchain:
-    description: Install a rust toolchain
+  print_rust_version_info:
+    description: Rust toolchain version info
     steps:
       - run:
-          name: Download rust
+          name: Rust version info
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2023-10-01 -y
+            rustup show
+            rustc --version
+            cargo --version
+            rustup --version
+
+  install_rustup:
+    description: Install rustup
+    steps:
+      - run:
+          name: Install rustup
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=none
 
   init_opam:
     description: Initialize opam
@@ -17,7 +28,7 @@ commands:
       - run:
           name: Init opam
           command: |
-            opam init --compiler=5.1.0 --disable-sandboxing -y
+            opam init --compiler=5.1.1 --disable-sandboxing -y
 
   setup_ocaml_tp:
     description: Write symlinks shim/third-party/ocaml
@@ -31,7 +42,8 @@ commands:
   setup_linux_env:
     description: Linux installation steps
     steps:
-      - install_rust_toolchain
+      - install_rustup
+      - print_rust_version_info
       - run:
           name: Aptitude install
           command: |
@@ -48,7 +60,8 @@ commands:
   setup_macos_env:
     description: macOS installation steps
     steps:
-      - install_rust_toolchain
+      - install_rustup
+      - print_rust_version_info
       - run:
           name: Brew install
           command: |

--- a/README-BUCK.md
+++ b/README-BUCK.md
@@ -17,7 +17,7 @@ Valid values for `$PLAT` are `x86_64-unknown-linux-gnu` on Linux, `x86_64-apple-
 
 It's also possible to install Buck2 from source into `~/.cargo/bin` like this.
 ```bash
-  cargo +nightly-2023-07-10 install --git https://github.com/facebook/buck2.git buck2
+  cargo install --git https://github.com/facebook/buck2.git buck2
 ```
 *Note: If on aarch64-apple-darwin then be sure install to `brew install protobuf` and for the now it's necessary to add
 ```bash
@@ -30,7 +30,7 @@ to the build environment.*
 
 Install the `reindeer` binary from source into '~/.cargo/bin' like this.
 ```bash
-    cargo +nightly-2023-07-10 install --git https://github.com/facebookincubator/reindeer.git reindeer
+    cargo install --git https://github.com/facebookincubator/reindeer.git reindeer
 ```
 
 *Note: Make sure after installing Buck2 and Reindeer to configure your `PATH` environment variable if necessary so they can be found.*

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-10-01"


### PR DESCRIPTION
Summary:
- use rust-toolchain for rustup to select channel and arrange documentation to keep it in sync with reindeer & buck2
- bump ocaml compiler to 5.1.1 as we've just done for buck2 D52803075

Differential Revision:
D52806266

Privacy Context Container: L1122763


