### PR TITLE
Commit the submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "prelude"]
+	path = prelude
+	url = https://github.com/facebook/buck2-prelude.git

--- a/README-BUCK.md
+++ b/README-BUCK.md
@@ -21,14 +21,7 @@ Instructions on how to setup a Buck2 build of ocamlrep. More Buck2 information &
 - Initialize a Buck2 prelude Git submodule.
 
      ```bash
-     git submodule add https://github.com/facebook/buck2-prelude.git prelude
      git submodule update --init
-     ```
-- Checkout the prelude at the right commit.
-
-     ```bash
-     prelude_hash=$(curl https://github.com/facebook/buck2/releases/download/latest/prelude_hash)
-     (cd prelude && git checkout $prelude_hash)
      ```
 
 ### Reindeer


### PR DESCRIPTION
This is part 1 of a 3 part series of diffs:
1. Update the submodule to be checked in instead of providing instructions in a doc
2. Update the buck2 binary to use OSS dotslash
3. Remove the prelude submodule completely (depends on some other changes to buck2 that haven't released yet)