### PR TITLE
fix the CI builds a bit

### DIFF
--- a/shim/third-party/ocaml/opam
+++ b/shim/third-party/ocaml/opam
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.


### PR DESCRIPTION
the .github workflows have been failing for some time. it would seem in fd0c69d the directory shim/third-party/ocaml/ got removed which has resulted in the `./ocaml-setup.sh` step in the workflows failing. this PR restores shim/third-party/ocaml/opam and the builds get further (the cargo build and test workflow succeeds in my testing)