### PR TITLE
Update third-party Rust crate versions

### DIFF
--- a/ocamlrep/test/test_bindings/Cargo.toml
+++ b/ocamlrep/test/test_bindings/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 cargo_test_utils = { path = "../../../cargo_test_utils" }
 ocamlrep = { path = "../.." }
 ocamlrep_caml_builtins = { path = "../../../ocamlrep_caml_builtins" }

--- a/ocamlrep_custom/test/Cargo.toml
+++ b/ocamlrep_custom/test/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 cargo_test_utils = { path = "../../cargo_test_utils" }
 ocamlrep_custom = { path = ".." }
 ocamlrep_ocamlpool = { path = "../../ocamlrep_ocamlpool" }

--- a/ocamlrep_derive/Cargo.toml
+++ b/ocamlrep_derive/Cargo.toml
@@ -22,5 +22,5 @@ syn = { version = "1.0.109", features = ["extra-traits", "fold", "full", "visit"
 synstructure = "0.12"
 
 [dev-dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 macro_test_util = { path = "../macro_test_util" }

--- a/ocamlrep_marshal/test/Cargo.toml
+++ b/ocamlrep_marshal/test/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 cargo_test_utils = { path = "../../cargo_test_utils" }
 ocamlrep = { path = "../../ocamlrep" }
 ocamlrep_marshal = { path = ".." }

--- a/ocamlrep_ocamlpool/test/Cargo.toml
+++ b/ocamlrep_ocamlpool/test/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 cargo_test_utils = { path = "../../cargo_test_utils" }
 ocamlrep_ocamlpool = { path = ".." }
 once_cell = "1.21"

--- a/rust_to_ocaml/rust_to_ocaml/Cargo.toml
+++ b/rust_to_ocaml/rust_to_ocaml/Cargo.toml
@@ -15,7 +15,7 @@ path = "rust_to_ocaml.rs"
 test = false
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 attr_parser = { path = "../attr_parser" }
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 convert_case = "0.11"

--- a/rust_to_ocaml/test/Cargo.toml
+++ b/rust_to_ocaml/test/Cargo.toml
@@ -14,7 +14,7 @@ name = "test_rust_to_ocaml"
 path = "test_rust_to_ocaml.rs"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 similar = { version = "2.2.0", features = ["bytes", "inline"] }
 walkdir = "2.3"


### PR DESCRIPTION
Summary:
Bump versions and add new Rust third-party crate dependencies needed by ripgrep.

**Version bumps:**
- `anyhow` 1.0.98 → 1.0.100
- `cfg-if` 1.0 → 1.0.4
- `log` 0.4.27 → 0.4.28
- `memchr` 2.7.5 → 2.7.6
- `serde_json` 1.0.140 → 1.0.145

**New crate dependencies added to Cargo.toml:**
- `arbitrary` 1.4.2
- `crossbeam-deque` 0.8.6
- `crossbeam-epoch` 0.9.18
- `crossbeam-utils` 0.8.21
- `derive_arbitrary` 1.4.2
- `find-msvc-tools` 0.1.5
- `jemalloc-sys` 0.6.1 (package: tikv-jemalloc-sys)
- `jobserver` 0.1.34
- `pcre2-sys` 0.2.10
- `ryu` 1.0.23
- `same-file` 1.0.6
- `serde_core` 1.0.228
- `wasip2` 1.0.1+wasi-0.2.4
- `winapi-util` 0.1.11
- `windows-link` 0.1.1
- `wit-bindgen` 0.46.0

Note for OSS projects: if you are reading this from GitHub pull requests, then it does not mean all of these crates will be added or updates, but only some subset that is used in the project.

Differential Revision: D93193734


